### PR TITLE
dir_ensure bug

### DIFF
--- a/cuisine/__init__.py
+++ b/cuisine/__init__.py
@@ -215,7 +215,7 @@ def dir_ensure( location, recursive=False, mode=None, owner=None, group=None ):
 		mode_arg = "-m %s" % (mode)
 	else:
 		mode_arg = ""
-	sudo("(test -d '%s' || mkdir %s %s '%s') && echo OK ; true" % (location, recursive and "-p" or "", mode_arg, location))
+	sudo("test -d '%s' || mkdir %s %s '%s' && echo OK ; true" % (location, recursive and "-p" or "", mode_arg, location))
 	if owner or group:
 		dir_attribs(location, owner=owner, group=group)
 


### PR DESCRIPTION
Hi Sebastien!

I found a bug in the dir_ensure in the line 218:

``` python
sudo("(test -d '%s' || mkdir %s %s '%s') && echo OK ; true" % (location, recursive and "-p" or "", mode_arg, location))
```

I got the error when I tried to use `dir_ensure`:

``` error
syntax error near unexpected token `('
```

there is no need to take the expression in parentheses in this line, like this:

``` python
sudo("test -d '%s' || mkdir %s %s '%s' && echo OK ; true" % (location, recursive and "-p" or "", mode_arg, location))
```
