### PR TITLE
Make package_ensure work as it failed to install packages.

### DIFF
--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -256,7 +256,8 @@ def package_install( package, update=False ):
 def package_ensure( package ):
 	"""Tests if the given package is installed, and installes it in case it's not
 	already there."""
-	if run("dpkg-query -W -f='${Status}' %s ; true" % package).find("installed") == -1:
+	if run("dpkg-query -W -f='${Status}' %s ; true" %
+			package).find("not-installed") != -1:
 		package_install(package)
 
 def command_ensure( command, package=None ):


### PR DESCRIPTION
Modified package_ensure test to not search for "installed" but to make sure "not-installed" was not present. As if a package is not installed on my debian squeeze box it outputs

"install ok not-installed"

Which contains the word "installed"
