### PR TITLE
remove unused import

### DIFF
--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -47,7 +47,6 @@ import os
 import random
 import re
 import string
-import time
 
 import fabric
 import fabric.api


### PR DESCRIPTION
We do not use the time module right now so let`s remove it until we really need it.
