### PR TITLE
Make system_uuid_alias_add syntax valid for python2.6

### DIFF
--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -558,10 +558,11 @@ def system_uuid_alias_add():
     /etc/hosts e.g. 127.0.0.1 localhost <hostname>.
 
     """
-    with mode_sudo(), cd('/etc'):
-        old = "127.0.0.1 localhost"
-        new = old + " " + system_uuid()
-        file_update('hosts', lambda x: text_replace_line(x, old, new)[0])
+    with mode_sudo():
+        with cd('/etc'):
+            old = "127.0.0.1 localhost"
+            new = old + " " + system_uuid()
+            file_update('hosts', lambda x: text_replace_line(x, old, new)[0])
 
 def system_uuid():
     """Gets a machines UUID (Universally Unique Identifier)."""


### PR DESCRIPTION
Python 2.6 does not support multiple context managers within with statement.
