### PR TITLE
Fix 2.6 invalid syntax in system_uuid_alias_add reintroduction

### DIFF
--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -593,14 +593,15 @@ def upstart_ensure(name):
 		sudo("service %s start" % name)
 
 def system_uuid_alias_add():
-	"""Adds system UUID alias to /etc/hosts.
-	Some tools/processes rely/want the hostname as an alias in
-	/etc/hosts e.g. `127.0.0.1 localhost <hostname>`.
-	"""
-	with mode_sudo(), cd('/etc'):
-			old = "127.0.0.1 localhost"
-			new = old + " " + system_uuid()
-			file_update('hosts', lambda x: text_replace_line(x, old, new)[0])
+    """Adds system UUID alias to /etc/hosts.
+    Some tools/processes rely/want the hostname as an alias in
+    /etc/hosts e.g. `127.0.0.1 localhost <hostname>`.
+    """
+    with mode_sudo(): 
+        with cd('/etc'):
+            old = "127.0.0.1 localhost"
+            new = old + " " + system_uuid()
+            file_update('hosts', lambda x: text_replace_line(x, old, new)[0])
 
 def system_uuid():
 	"""Gets a machines UUID (Universally Unique Identifier)."""


### PR DESCRIPTION
fixes #35
