### PR TITLE
mode_sudo more awarnes

### DIFF
--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -492,7 +492,8 @@ def dir_ensure(location, recursive=False, mode=None, owner=None, group=None):
 
 	If we are not updating the owner/group then this can be done as a single
 	ssh call, so use that method, otherwise set owner/group after creation."""
-	run('test -d "%s" || mkdir %s "%s" && echo OK ; true' % (location, recursive and "-p" or "", location))
+	if not dir_exists(location):
+		run('mkdir %s "%s" && echo OK ; true' % (recursive and "-p" or "", location))
 	if owner or group or mode:
 		dir_attribs(location, owner=owner, group=group, mode=mode)
 


### PR DESCRIPTION
Hi, I have just fixed a problem I met. It is problem with sudo and || and && notation which sudo does not take care of and so this part is run with permission of owner.. yep so I was wondering why I cant create directory in /hosts and in /tmp I can... 

So for further commands I suggest more of awareness that the command might be run with sudo..
