### PR TITLE
Try calling commands with sudo if they fail otherwise in file_attribs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,34 @@
 #!/usr/bin/env python
 # Encoding: utf-8
 # See: <http://docs.python.org/distutils/introduction.html>
-from distutils.core import setup
-import os, sys
-VERSION = eval(filter(lambda _:_.startswith("VERSION"), file("src/cuisine.py").readlines())[0].split("=")[1])
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
+VERSION = eval(filter(lambda _:_.startswith("VERSION"),
+    file("src/cuisine.py").readlines())[0].split("=")[1])
+
 setup(
-	name             = "cuisine",
-	version          = VERSION,
-	description      = "Chef-like functionality for Fabric",
-	author           = "Sébastien Pierre",
-	author_email     = "sebastien.pierre@gmail.com",
-	url              = "http://github.com/sebastien/cuisine",
-	download_url     = "https://github.com/sebastien/cuisine/tarball/%s" % (VERSION),
-	keywords         = ["fabric", "chef", "ssh",],
-	install_requires = ["fabric",],
-	package_dir      = {"":"src"},
-	py_modules       = ["cuisine"],
-	classifiers      = [
-		"Programming Language :: Python",
-		"Development Status :: 3 - Alpha",
-		"Natural Language :: English",
-		"Environment :: Web Environment",
-		"Intended Audience :: Developers",
-		"Operating System :: OS Independent",
-		"Topic :: Utilities"
-	],
+    name             = "cuisine",
+    version          = VERSION,
+    description      = "Chef-like functionality for Fabric",
+    author           = "Sébastien Pierre",
+    author_email     = "sebastien.pierre@gmail.com",
+    url              = "http://github.com/sebastien/cuisine",
+    download_url     = "https://github.com/sebastien/cuisine/tarball/%s" % (VERSION),
+    keywords         = ["fabric", "chef", "ssh",],
+    install_requires = ["fabric",],
+    package_dir      = {"":"src"},
+    py_modules       = ["cuisine"],
+    classifiers      = [
+        "Programming Language :: Python",
+        "Development Status :: 3 - Alpha",
+        "Natural Language :: English",
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+        "Topic :: Utilities"
+    ],
 )
 # EOF - vim: ts=4 sw=4 noet

--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -354,13 +354,18 @@ def file_is_link(location):
 def file_attribs(location, mode=None, owner=None, group=None, recursive=False):
 	"""Updates the mode/owner/group for the remote file at the given
 	location."""
+	def run_or_sudo(cmd):
+		with fabric.api.settings(warn_only=True):
+			r = run(cmd)
+        	if r.return_code != 0:
+				sudo(cmd)
 	recursive = recursive and "-R " or ""
 	if mode:
-		run('chmod %s %s "%s"' % (recursive, mode,  location))
+		run_or_sudo('chmod %s %s "%s"' % (recursive, mode,  location))
 	if owner:
-		run('chown %s %s "%s"' % (recursive, owner, location))
+		run_or_sudo('chown %s %s "%s"' % (recursive, owner, location))
 	if group:
-		run('chgrp %s %s "%s"' % (recursive, group, location))
+		run_or_sudo('chgrp %s %s "%s"' % (recursive, group, location))
 
 def file_attribs_get(location):
 	"""Return mode, owner, and group for remote path.


### PR DESCRIPTION
While using  `file_attribs()` to deploy something on a vagrant instance, the script would fail on `chown`, with a message like:

```
chown  deploy "/tmp/src.tar.bz2"
chown: changing ownership of `/tmp/src.tar.bz2': Operation not permitted
```

This patch patches `file_attribs()` calls the command with `sudo()`, if `run()` fails.

Also, I couldn't get setup.py develop to work, patched setup.py to use setuptools instead of distutils.
