### PR TITLE
make "file_*" tests less susceptible to unexpected output breakage

### DIFF
--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -361,16 +361,16 @@ def file_read(location):
 
 def file_exists(location):
 	"""Tests if there is a *remote* file at the given location."""
-	return run('test -e "%s" && echo OK ; true' % (location)) == "OK"
+	return run('test -e "%s" && echo OK ; true' % (location)).endswith("OK")
 
 def file_is_file(location):
-	return run("test -f '%s' && echo OK ; true" % (location)) == "OK"
+	return run("test -f '%s' && echo OK ; true" % (location)).endswith("OK")
 
 def file_is_dir(location):
-	return run("test -d '%s' && echo OK ; true" % (location)) == "OK"
+	return run("test -d '%s' && echo OK ; true" % (location)).endswith("OK")
 
 def file_is_link(location):
-	return run("test -L '%s' && echo OK ; true" % (location)) == "OK"
+	return run("test -L '%s' && echo OK ; true" % (location)).endswith("OK")
 
 def file_attribs(location, mode=None, owner=None, group=None, recursive=False):
 	"""Updates the mode/owner/group for the remote file at the given


### PR DESCRIPTION
I had an incorrect hostname set on my machine, which caused the output of:

```
run('test -e "%s" && echo OK ; true' % (location))
```

to be:

```
'sudo: unable to resolve host experiment-2.local\r\nOK'
```

So even though the file existed, it failed because of the unexpected output. I noticed a few other functions (e.g. `dir_exists`) had a workaround for this, so I made all of the `file_*` checks match that logic.

Note: I think a better way to do this kind of check is using `with settings(warn_only=True)` and then check the exit code of the command. That way you aren't relying on the text output, and you don't need the extra logic like `cmd && echo OK ; true`
