### PR TITLE
logic of is_sudo inverted

### DIFF
--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -117,7 +117,7 @@ def mode(key):
 
 def is_local():  return mode(MODE_LOCAL)
 def is_remote(): return not mode(MODE_LOCAL)
-def is_sudo():   return not mode(MODE_SUDO)
+def is_sudo():   return mode(MODE_SUDO)
 
 # =============================================================================
 #


### PR DESCRIPTION
is seems the logic of is_sudo is the opposite of what it should be:

```
def is_sudo():   return not mode(MODE_SUDO)
```

as a result normal commands are all executing with sudo
