### PR TITLE
Fixes newline stripping for local mode commands

### DIFF
--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -155,7 +155,7 @@ def run_local(command, sudo=False, shell=True, pty=True, combine_stderr=None):
 	# FIXME: Should stream the output, and only print it if fabric's properties allow it
 	# print out
 	# Wrap stdout string and add extra status attributes
-	result = fabric.operations._AttributeString(out)
+	result = fabric.operations._AttributeString(out.rstrip('\n'))
 	result.return_code = process.returncode
 	result.succeeded   = process.returncode == 0
 	result.failed      = not result.succeeded

--- a/tests/all.py
+++ b/tests/all.py
@@ -188,6 +188,17 @@ class Files(unittest.TestCase):
 			file_sig = hashlib.sha256(f.read()).hexdigest()
 		assert sig == file_sig
 
+	def testExists( self ):
+		try:
+			fd, path = tempfile.mkstemp()
+			f = os.fdopen(fd, 'w')
+			f.write('Hello World!')
+			f.close()
+			assert cuisine.file_exists(path)
+		finally:
+			os.unlink(path)
+
+
 class Packages(unittest.TestCase):
 
 	def testInstall( self ):


### PR DESCRIPTION
file_exists() and similar commands were failing in local mode because their output ended with "OK\n", not "OK".  This patch strips the output appropriately and adds a basic unit test for file_exists().
