### PR TITLE
PEP8, consistency and a few bug fixes.

### DIFF
--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -799,7 +799,7 @@ def python_package_upgrade_pip(package, E=None):
         E = '-E %s' % E
     else:
         E = ''
-        run('pip upgrade %s %s' % (E, package))
+    run('pip upgrade %s %s' % (E, package))
 
 
 def python_package_install_pip(package=None, r=None, pip=None):


### PR DESCRIPTION
Here are a few commits to give cuisine.py more consistincy and pretty close to PEP8. The biggest ones are the Untabify and teh use 4 spaces for indent. All the others are pretty much dependent on these.

I tried to break up the commits based on the PEP8 section that they applied and have attached any relevant PEP8 link into the commit messages.

Let me know if this is too intrusive.
