### PR TITLE
clean up mode switching and compression in file_write

### DIFF
--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -570,17 +570,17 @@ def package_update_apt(package=None):
 	else:
 		if type(package) in (list, tuple):
 			package = " ".join(package)
-		sudo("apt-get --yes upgrade " + package)
+		sudo('DEBIAN_FRONTEND=noninteractive apt-get --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade ' + package)
 
 def package_upgrade_apt():
-	sudo("apt-get --yes upgrade")
+	sudo('DEBIAN_FRONTEND=noninteractive apt-get --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade')
 
 def package_install_apt(package, update=False):
 	if update:
-		sudo("apt-get --yes update")
+		sudo('DEBIAN_FRONTEND=noninteractive apt-get --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" update')
 	if type(package) in (list, tuple):
 		package = " ".join(package)
-	sudo("apt-get --yes install %s" % (package))
+	sudo("DEBIAN_FRONTEND=noninteractive apt-get --yes install %s" % (package))
 
 def package_ensure_apt(package, update=False):
 	status = run("dpkg-query -W -f='${Status}' %s ; true" % package)


### PR DESCRIPTION
file_write was defaulting to using sudo, which should definitely not be the case. part of the problem was that mode was returning True, False, and None and mode_\* called with None would default to True for mode_sudo. 

mode should now return True or False, file_write determines whether to use sudo correctly, switch to bzip2 since gzip.zlib does not write gzip headers, and make a few things compatible with OSX.
