### PR TITLE
Fixed add-apt-repository

### DIFF
--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -617,7 +617,7 @@ def package_clean(package=None):
 # -----------------------------------------------------------------------------
 
 def repository_ensure_apt(repository):
-	sudo("add-apt-repository " + repository)
+	sudo("add-apt-repository --yes" + repository)
 
 def package_update_apt(package=None):
 	if package == None:


### PR DESCRIPTION
Added --yes to add-apt-repository to prevent prompting (which causes cuisine to be unresponsive)
