### PR TITLE
Install packages required for add-apt-repository

### DIFF
--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -637,6 +637,7 @@ def package_remove(package, autoclean=False):
 # -----------------------------------------------------------------------------
 
 def repository_ensure_apt(repository):
+	package_ensure_apt('python-software-properties')
 	sudo("add-apt-repository --yes" + repository)
 
 def package_update_apt(package=None):


### PR DESCRIPTION
To run `add-apt-repository` `python-software-properties` must be installed. (Which isn't a default package in many cases!)
