### PR TITLE
Fix for sudo in file_upload

### DIFF
--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -464,7 +464,7 @@ def file_upload(remote, local, sudo=None):
 	if not file_exists(remote) or sig != file_md5(remote):
 		if is_local():
 			if use_sudo:
-				sudo('cp "%s" "%s"'%(local,remote))
+				globals()['sudo']('cp "%s" "%s"'%(local,remote))
 			else:
 				run('cp "%s" "%s"'%(local,remote))
 		else:


### PR DESCRIPTION
If you're in is_local mode, sudo() is called, but sudo is also passed in on kwargs. I assume this needs to be the global sudo.

This is an ugly fix but preserves the syntax of the function api.
