### PR TITLE
Adding SCP option to file_write, file_ensure and file_upload

### DIFF
--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -420,7 +420,8 @@ def file_write(location, content, mode=None, owner=None, group=None, sudo=None, 
 				run('cp "%s" "%s"'%(local_path,location))
 		else:
 			if scp:
-				scp_cmd = 'scp "%s" "%s"@"%s":"%s"'%(local_path,fabric.api.env.user,fabric.api.env.host_string,location)
+				hostname = fabric.api.env.host_string if len(fabric.api.env.host_string.split(':')) == 1 else fabric.api.env.host_string.split(':')[0]
+				scp_cmd = 'scp "%s" "%s"@"%s":"%s"'%(local_path,fabric.api.env.user,hostname,location)
 				print('[localhost] ' +  scp_cmd)
 				run_local(scp_cmd)
 			else:
@@ -474,7 +475,8 @@ def file_upload(remote, local, sudo=None, scp=False):
 				run('cp "%s" "%s"'%(local,remote))
 		else:
 			if scp:
-				scp_cmd = 'scp "%s" "%s"@"%s":"%s"'%(local,fabric.api.env.user,fabric.api.env.host_string,remote)
+				hostname = fabric.api.env.host_string if len(fabric.api.env.host_string.split(':')) == 1 else fabric.api.env.host_string.split(':')[0]
+				scp_cmd = 'scp "%s" "%s"@"%s":"%s"'%(local,fabric.api.env.user,hostname,remote)
 				print('[localhost] ' +  scp_cmd)
 				run_local(scp_cmd)
 			else:


### PR DESCRIPTION
To get around problems with file_write failing on large files, using
SCP : have added scp=False as an optional parameter to file_write, file_ensure, file_upload

limitations:
  requires host and user to have been initialised
  will fail silently (should add a file_ensure check after?)

An alternative approach would be to use scpclient (with modifications) that implements scp on top of paramiko  - this has its own issues and would require a modified package to be installed - so possibly too complex?

Feel free to comment and will update.
