### PR TITLE
need_passwd option for user_check

### DIFF
--- a/tests/all.py
+++ b/tests/all.py
@@ -24,6 +24,17 @@ class Users(unittest.TestCase):
 		assert cuisine.user_check(uid=user_data["uid"])
 		assert cuisine.user_check(uid=user_data["uid"])["name"] == user_data["name"]
 
+	def testUserCheckNeedPasswd( self ):
+		user_data = cuisine.user_check(USER, need_passwd=False)
+		user_data_with_passwd = cuisine.user_check(name=USER)
+		assert user_data
+		assert user_data["name"] == USER
+		assert 'passwd' in user_data_with_passwd
+		assert 'passwd' not in user_data
+		# We ensure that user_check works with uid and name
+		assert cuisine.user_check(uid=user_data["uid"], need_passwd=False)
+		assert cuisine.user_check(uid=user_data["uid"], need_passwd=False)["name"] == user_data["name"]
+
 class Modes(unittest.TestCase):
 
 	def testModeLocal( self ):
@@ -63,7 +74,7 @@ class Modes(unittest.TestCase):
 # 			with cd(tmpdir), cuisine.mode_sudo():
 # 				cuisine.run('echo "test" > test.txt')
 # 				cuisine.run('chmod 0600 test.txt')
-# 
+#
 # 			with cd(tmpdir), cuisine.mode_user(), settings(warn_only=True):
 # 				listing = cuisine.run('ls -la test.txt').split()
 # 				self.assertEqual('root', listing[2])  # user
@@ -76,7 +87,7 @@ class Modes(unittest.TestCase):
 
 # NOTE: Test disabled for now
 # class LocalExecution(unittest.TestCase):
-# 
+#
 # 	def testFabricLocalCommands( self ):
 # 		'''
 # 		Make sure local and lcd still work properly and that run and cd
@@ -87,31 +98,31 @@ class Modes(unittest.TestCase):
 # 			dir1 = os.path.join(tmpdir, 'test1')
 # 			dir2 = os.path.join(tmpdir, 'test2')
 # 			[os.mkdir(d) for d in [dir1, dir2]]
-# 			
+#
 # 			with cd(dir1), fabric.api.lcd(dir2):
 # 				file1 = os.path.join(dir1, 'test1.txt')
 # 				cuisine.run('touch %s' % file1)
-# 
+#
 # 				file2 = os.path.join(dir2, 'test2.txt')
 # 				fabric.api.local('touch %s' % file2)
-# 
+#
 # 				self.assertTrue(cuisine.file_exists(file2))
 # 		finally:
 # 			shutil.rmtree(tmpdir)
-# 
-# 
+#
+#
 # 	def testResultAttributes( self ):
 # 		failing_command = 'cat /etc/shadow'	# insufficient permissions
 # 		succeeding_command = 'uname -a'
 # 		erroneous_command = 'this-command-does-not-exist -a'
-# 
+#
 # 		# A successful command should have the appropriate status
 # 		# attributes set
 # 		result = cuisine.run(succeeding_command)
 # 		self.assertTrue(result.succeeded)
 # 		self.assertFalse(result.failed)
 # 		self.assertEqual(result.return_code, 0)
-# 
+#
 # 		# With warn_only set, we should be able to examine the result
 # 		# even if it fails
 # 		with settings(warn_only=True):
@@ -122,29 +133,29 @@ class Modes(unittest.TestCase):
 # 			self.assertEqual(result.return_code, 1)
 # 			self.assertIsNotNone(result.stderr)
 # 			self.assertIn('Permission denied', result.stderr)
-# 
+#
 # 		# With warn_only off, failure should cause execution to abort
 # 		with settings(warn_only=False):
 # 			with self.assertRaises(SystemExit):
 # 				cuisine.run(failing_command)
-# 
+#
 # 		# An erroneoneous command should fail similarly to fabric
 # 		with settings(warn_only=True):
 # 			result = cuisine.run(erroneous_command)
 # 			self.assertTrue(result.failed)
 # 			self.assertEqual(result.return_code, 127)
-# 
+#
 # 	def testCd( self ):
 # 		with cd('/tmp'):
 # 			self.assertEqual(cuisine.run('pwd'), '/tmp')
-# 
+#
 # 	def testShell( self ):
-# 		# Ensure that env.shell is respected by setting it to the 
+# 		# Ensure that env.shell is respected by setting it to the
 # 		# 'exit' command and testing that it aborts.
 # 		with settings(use_shell=True, shell='exit'):
 # 			with self.assertRaises(SystemExit):
 # 				cuisine.run('ls')
-# 
+#
 # 	def testSudoPrefix( self ):
 # 		# Ensure that env.sudo_prefix is respected by setting it to
 # 		# echo the command to stdout rather than executing it
@@ -155,12 +166,12 @@ class Modes(unittest.TestCase):
 # 			self.assertNotEqual(run_result.stdout, sudo_result.stdout)
 # 			self.assertIn(env.shell, sudo_result)
 # 			self.assertIn(cmd, sudo_result)
-# 
+#
 # 	def testPath( self ):
-# 		# Make sure the path is applied properly by setting it empty 
+# 		# Make sure the path is applied properly by setting it empty
 # 		# and making sure that stops a simple command from running
 # 		self.assertTrue(cuisine.run('ls').succeeded)
-# 
+#
 # 		with fabric.api.path(' ', behavior='replace'), settings(warn_only=True):
 # 			result = cuisine.run('ls', combine_stderr=False)
 # 			self.assertTrue(result.failed)


### PR DESCRIPTION
user_check is useful function but it also needs sudo access
sudo access is primarily required to parse /etc/shadow.
There are situations when
    - passwd is not required information
    - sudo access is not desired/possible

So added need_passwd parameter to user_check().
- default is True to make sure existing use cases do not break
- added tests

with need_passwd=False user_check runs much faster :)
