### PR TITLE
Allow user to define pip executable during package upgrade via pip

### DIFF
--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -971,11 +971,12 @@ def python_package_remove(package):
 # PIP PYTHON PACKAGE MANAGER
 # -----------------------------------------------------------------------------
 
-def python_package_upgrade_pip(package):
+def python_package_upgrade_pip(package, pip=None):
 	'''
 	The "package" argument, defines the name of the package that will be upgraded.
 	'''
-	run('pip install --upgrade %s' %(package))
+	pip=pip or fabric.api.env.get('pip','pip')
+	run('%s install --upgrade %s' %(pip, package))
 
 def python_package_install_pip(package=None,r=None,pip=None):
 	'''


### PR DESCRIPTION
python_package_upgrade_pip lacks pip kwarg.