### PR TITLE
Upstart scripts

### DIFF
--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -1352,6 +1352,15 @@ def upstart_ensure(name):
 	if status.failed:
 		sudo("service %s start" % name)
 
+
+def upstart_stop(name):
+	"""Ensures that the given upstart service is stopped."""
+	with fabric.api.settings(warn_only=True):
+		status = sudo("service %s status" % name)
+	if status.succeeded:
+		sudo("service %s stop" % name)
+
+
 # =============================================================================
 #
 # SYSTEM


### PR DESCRIPTION
- Fixing issue #152
- Adding a way to ensure that a upstart service is stopped
