### PR TITLE
run "pip install" as root

### DIFF
--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -1219,7 +1219,7 @@ def python_package_install_pip(package=None,r=None,pip=None):
 	'''
 	pip=pip or fabric.api.env.get('pip','pip')
 	if package:
-		run('%s install %s' %(pip,package))
+		sudo('%s install %s' %(pip,package))
 	elif r:
 		run('%s install -r %s' %(pip,r))
 	else:


### PR DESCRIPTION
Had to change 'run' to 'sudo' for `python_package_install_pip` to work.  I'm not sure why `python_package_install_easy_install` used `sudo` and `python_package_install_pip`used `run` 
