### PR TITLE
avoid interactivity of "service * status" command pager.

### DIFF
--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -2085,7 +2085,7 @@ def upstart_ensure(name):
 	"""Ensures that the given upstart service is running, starting
 	it if necessary."""
 	with fabric.api.settings(warn_only=True):
-		status = sudo("service %s status" % name)
+		status = sudo("service %s status|cat" % name)
 	if status.failed:
 		status = sudo("service %s start" % name)
 	return status
@@ -2102,7 +2102,7 @@ def upstart_restart(name):
 	"""Tries a `restart` command to the given service, if not successful
 	will stop it and start it. If the service is not started, will start it."""
 	with fabric.api.settings(warn_only=True):
-		status = sudo("service %s status" % name)
+		status = sudo("service %s status|cat" % name)
 	if status.failed:
 		return sudo("service %s start" % name)
 	else:
@@ -2116,7 +2116,7 @@ def upstart_restart(name):
 def upstart_stop(name):
 	"""Ensures that the given upstart service is stopped."""
 	with fabric.api.settings(warn_only=True):
-		status = sudo("service %s status" % name)
+		status = sudo("service %s status|cat" % name)
 	if status.succeeded:
 		status = sudo("service %s stop" % name)
 	return status


### PR DESCRIPTION
Hi

I am now using fabric and cuisine to setup Ubuntu 16.4 server.
But It stopped by interactivity while calling upstart_ensure,
because the "service * status" calls pager, less or something.
This patch is for this problem. please merge this.

[example problem situation(multibyte characters are Japanese chars)]
[xxx.xxx.xxx.xxx] out:  2月 09 10:53:29 ip-10-0-0-147 systemd[1]: Starting A high performance web s
[xxx.xxx.xxx.xxx] out:  2月 09 10:53:29 ip-10-0-0-147 systemd[1]: nginx.service: Failed to read PID
[xxx.xxx.xxx.xxx] out:  2月 09 10:53:29 ip-10-0-0-147 systemd[1]: Started A high performance web se
[xxx.xxx.xxx.xxx] out: lines 1-17/17 (END)  C-c C-c
Stopped.
Disconnecting from xxx.xxx.xxx.xxx... done.